### PR TITLE
Helpers is included in the global scope

### DIFF
--- a/hud.lua
+++ b/hud.lua
@@ -1,5 +1,3 @@
-require("Helpers")
-
 system.showScreen(1)
 
 function getRelativePitch(velocity) 


### PR DESCRIPTION
Helpers is already required from the `global.lua`